### PR TITLE
修复了进入游戏后挥动(swing)会导致无法移动的问题

### DIFF
--- a/Player/player.gd
+++ b/Player/player.gd
@@ -55,6 +55,7 @@ func _ready() -> void:
 	jian_qi.hide()
 	can_move = true
 	effects.hide()
+	player_direction=Vector2.DOWN
 	#只有部分代码需要在场景转换时重新赋值
 	initial()
 	SceneManager.level_changed.connect(initial)


### PR DESCRIPTION
修改：在player.gd的_ready()中给player_direction添加了初始值Vector2.DOWN

问题描述和复现方法：
进入游戏后，先挥动武器“喵刀”或”镰刀“，人物无法移动。
若此时切换到其他道具，并左键进行动作后，人物可以正常移动。

修复思路：
考虑到可能是有限状态机的问题，通过在Player\States\swing.gd中的_physics_update添加调试语句，发现进入游戏后挥动瞄刀，
anim会一直播放Idle_down的动画。由于该动画是循环播放的，因此anim.is_playing()永远为真。角色会永远停留在swing状态，从而无法移动。

而导致anim会播放idle_down动画的原因是，进入游戏后player.player_direction没有初始值，并不是_update_animation()中所设定的四种情况的任意一种，因此没有切换到swing_up，swing_down等动画，而是停留在原来的待机动画idle_down

因此，解决这个问题的方法就是给player的player_direction设定一个初始值。结合初始任务朝向，将其设定为Vector2.DOWN即可


调试语句：
Player\States\swing.gd

```
func _physics_update(delta):
	print("anim.is_playing() ")
	print(anim.is_playing()) #todo : 问题在于anim.is_playing()会一直为真
	print(anim.current_animation)
	print("anim.current_animation_length: %f"%anim.current_animation_length)
	print("anim.current_animation_position: %f"%anim.current_animation_position)
	if !anim.is_playing():
		#queue_projectile()
		if player.direction == Vector2.ZERO:
			transition_to.emit("Idle")
		else:
			transition_to.emit("Move")
```

Player\player.gd
修复：

```
func _ready() -> void:
	bag_system.items.resize(bag_system.items_size)
	items = bag_system.items
	weapon.hide()
	weapon.offset = Vector2(12,-12)
	weapon.flip_h = false
	weapon.position = Vector2(0,-12)
	jian_qi.hide()
	can_move = true
	effects.hide()
	player_direction=Vector2.DOWN   # 添加了这一行
	#只有部分代码需要在场景转换时重新赋值
	initial()
	SceneManager.level_changed.connect(initial)
```
